### PR TITLE
mission page and components

### DIFF
--- a/nefac-website/src/App.tsx
+++ b/nefac-website/src/App.tsx
@@ -5,7 +5,7 @@ import SustainingMembershipsPage from "./app/pages/sustaining-memberships/page";
 import NewsPage from "./app/pages/nefac-news/page";
 import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 import Header from "./app/components/header";
-
+import MissionPage from "./app/pages/mission/page";
 const App = () => {
 
   return (
@@ -15,6 +15,7 @@ const App = () => {
       <Routes>
         <Route path="/nefac-news" element={<NewsPage />} />
         <Route path="/sustaining-memberships" element={<SustainingMembershipsPage />} />
+        <Route path="/mission" element={<MissionPage />} />
       </Routes>
     </Router>
     </>

--- a/nefac-website/src/app/components/ImageCollage.tsx
+++ b/nefac-website/src/app/components/ImageCollage.tsx
@@ -1,0 +1,38 @@
+import React from "react";
+
+interface ImageCollageProps {
+  images: string[];
+}
+
+const ImageCollage: React.FC<ImageCollageProps> = ({ images }) => {
+  return (
+    <div className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-5 gap-2">
+      {images.map((src, index) => (
+        <img 
+          key={index} 
+          src={src} 
+          alt={`Member ${index + 1}`} 
+          className="w-full aspect-square object-cover border-2 border-gray-300"
+          loading="lazy"
+        />
+      ))}
+    </div>
+  );
+};
+
+const defaultTeamImages: string[] = [
+  "/images/team-1.png", "/images/team-2.png", "/images/team-3.png", "/images/team-4.png",
+  "/images/team-5.png", "/images/team-6.png", "/images/team-7.png", "/images/team-8.png",
+  "/images/team-9.png", "/images/team-10.png", "/images/team-11.png", "/images/team-12.png",
+  "/images/team-13.png", "/images/team-14.png", "/images/team-15.png", "/images/team-16.png",
+  "/images/team-17.png", "/images/team-18.png", "/images/team-19.png", "/images/team-20.png",
+  "/images/team-21.png", "/images/team-22.png", "/images/team-23.png", "/images/team-24.png",
+  "/images/team-25.png"
+];
+
+// if no custom images are provided, use the default team images
+export function ImageCollageWrapper() {
+  return <ImageCollage images={defaultTeamImages} />;
+}
+
+export default ImageCollage;

--- a/nefac-website/src/app/pages/mission/page.tsx
+++ b/nefac-website/src/app/pages/mission/page.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import NefacMission from '../../../components/nefac-mission';
+
+const MissionPage = () => {
+  return (
+    <div className="min-h-screen">
+      <NefacMission />
+    </div>
+  );
+};
+
+export default MissionPage;

--- a/nefac-website/src/components/nefac-mission.tsx
+++ b/nefac-website/src/components/nefac-mission.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { ImageCollageWrapper } from '../app/components/ImageCollage';
+
+const styles = {
+  container: `max-w-6xl mx-auto px-4 py-12 md:py-16`,
+  contentWrapper: `flex flex-col md:flex-row gap-8 md:gap-12`,
+  textSection: `w-full md:w-2/3 space-y-4 text-md`,
+  title: `text-2xl font-bold text-[rgba(47,92,159,1)] mb-8 font-poppins`,
+  paragraph: `text-gray-700 font-inter`,
+  highlight: `font-semibold text-[rgba(47,92,159,1)]`,
+  imageSection: `w-full md:w-1/2 flex justify-center md:justify-end`,
+  taxInfo: `mt-4 text-gray-600 font-inter`,
+} as const;
+
+
+export default function NefacMission() {
+  return (
+    <section className={styles.container}>
+      <div className={styles.contentWrapper}>
+        <div className={styles.textSection}>
+          <h2 className={styles.title}>NEFAC's MISSION</h2>
+          
+          <p className={styles.paragraph}>
+            The New England First Amendment Coalition <strong>defends, promotes</strong>, and <strong>expands</strong>{' '}
+            public access to government and the work it does. The 
+            coalition is a broad-based organization of people who believe in the 
+            power of transparency in a democratic society. Its members include{' '}
+            <strong>lawyers, journalists, historians, librarians, and academicians</strong>, as well as 
+            private citizens and organizations whose core beliefs include the 
+            principles of the First Amendment.
+          </p>
+          
+          <p className={styles.paragraph}>
+            The coalition aspires to advance and <strong>protect the five freedoms of the 
+            First Amendment</strong>, and the principle of the public's right to know, in{' '}
+            <strong>Connecticut, Maine, Massachusetts, New Hampshire, Rhode Island, and Vermont</strong>. 
+            In collaboration with other like-minded advocacy 
+            organizations, NEFAC also seeks to <strong>advance understanding of the 
+            First Amendment</strong> across the nation and freedom of speech and press 
+            issues around the world.
+          </p>
+          
+          <p className={styles.taxInfo}>
+            NEFAC is a 501(c)(3) non-profit organization. Tax ID: 20-4826233.
+          </p>
+        </div>
+        
+        <div className={styles.imageSection}>
+          <ImageCollageWrapper />
+        </div>
+      </div>
+    </section>
+  );
+} 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/8f184346-8389-4329-a2f9-a1a6af6ea338)
This pull request introduces a new "Mission" page to the NEFAC website and adds an image collage component. The most important changes include adding the `MissionPage` component, integrating the new page into the router, and creating an `ImageCollage` component to display images.

### New Page Addition:

* [`nefac-website/src/App.tsx`](diffhunk://#diff-c83f9131e87163f40c30f2fcd0906ae7d77b4c1b566238bd9726e3c7242e5b61L8-R8): Added import for `MissionPage` and included a new route for the mission page in the router. [[1]](diffhunk://#diff-c83f9131e87163f40c30f2fcd0906ae7d77b4c1b566238bd9726e3c7242e5b61L8-R8) [[2]](diffhunk://#diff-c83f9131e87163f40c30f2fcd0906ae7d77b4c1b566238bd9726e3c7242e5b61R18)
* [`nefac-website/src/app/pages/mission/page.tsx`](diffhunk://#diff-eb88c5ef1f9e2f27c481906b8b2404cdc5b09a5a4cacc3c45215cb7cdca6482cR1-R12): Created the `MissionPage` component that renders the `NefacMission` component.

### New Components:

* [`nefac-website/src/app/components/ImageCollage.tsx`](diffhunk://#diff-c9404da34dbfbc4fe9272d27d02f369bf852b9c5319ad4a6fbe6528d8326973aR1-R38): Introduced `ImageCollage` component to display a grid of images, with a wrapper component to use default team images if no custom images are provided.
* [`nefac-website/src/components/nefac-mission.tsx`](diffhunk://#diff-1ffdb4f7826de620e5e0f7652e8275c6d047b985e547d610d57a19228003ccfcR1-R54): Created `NefacMission` component to display the mission statement and an image collage using the `ImageCollageWrapper`.

### Notes:

- font will not work until other PR is merged.
- to pass down image props use ImageCollage component  rather than the wrapper which gives placeholder images.

### Closes: 
#25 