### PR TITLE
implement commentary section

### DIFF
--- a/nefac-website/package-lock.json
+++ b/nefac-website/package-lock.json
@@ -8,8 +8,10 @@
       "name": "nefac-website",
       "version": "0.1.0",
       "dependencies": {
+        "@radix-ui/react-slot": "^1.1.2",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "embla-carousel-react": "^8.5.2",
         "lucide-react": "^0.475.0",
         "next": "15.1.6",
         "react": "^19.0.0",
@@ -1369,6 +1371,39 @@
         "node": ">=14"
       }
     },
+    "node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.1.tgz",
+      "integrity": "sha512-Y9VzoRDSJtgFMUCoiZBDVo084VQ5hfpXxVE+NgkdNsjiDBByiImMZKKhxMwCbdHvhlENG6a833CbFkOQvTricw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.1.2.tgz",
+      "integrity": "sha512-YAKxaiGsSQJ38VzKH86/BPRC4rh+b1Jpa+JneA5LRE7skmLPNAyeG8kPJj/oo4STLvlrs8vkf/iYyc3A5stYCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.34.8",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.34.8.tgz",
@@ -1973,7 +2008,7 @@
       "version": "19.0.8",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.0.8.tgz",
       "integrity": "sha512-9P/o1IGdfmQxrujGbIMDyYaaCykhLKc0NGCtYcECNUr9UAaDe4gwvV9bR6tvd5Br1SG0j+PBpbKr2UYY8CwqSw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -2369,7 +2404,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/debug": {
@@ -2427,6 +2462,34 @@
       "integrity": "sha512-eHhqaja8tE/FNpIiBrvBjFV/SSKpyWHLvxuR9dPTdo+3V9ppdLmFB7ZZQ98qNovcngPLYIz0oOBF9P0FfZef5Q==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/embla-carousel": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.5.2.tgz",
+      "integrity": "sha512-xQ9oVLrun/eCG/7ru3R+I5bJ7shsD8fFwLEY7yPe27/+fDHCNj0OT5EoG5ZbFyOxOcG6yTwW8oTz/dWyFnyGpg==",
+      "license": "MIT"
+    },
+    "node_modules/embla-carousel-react": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/embla-carousel-react/-/embla-carousel-react-8.5.2.tgz",
+      "integrity": "sha512-Tmx+uY3MqseIGdwp0ScyUuxpBgx5jX1f7od4Cm5mDwg/dptEiTKf9xp6tw0lZN2VA9JbnVMl/aikmbc53c6QFA==",
+      "license": "MIT",
+      "dependencies": {
+        "embla-carousel": "8.5.2",
+        "embla-carousel-reactive-utils": "8.5.2"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.1 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/embla-carousel-reactive-utils": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/embla-carousel-reactive-utils/-/embla-carousel-reactive-utils-8.5.2.tgz",
+      "integrity": "sha512-QC8/hYSK/pEmqEdU1IO5O+XNc/Ptmmq7uCB44vKplgLKhB/l0+yvYx0+Cv0sF6Ena8Srld5vUErZkT+yTahtDg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "embla-carousel": "8.5.2"
+      }
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",

--- a/nefac-website/package.json
+++ b/nefac-website/package.json
@@ -9,8 +9,10 @@
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx"
   },
   "dependencies": {
+    "@radix-ui/react-slot": "^1.1.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "embla-carousel-react": "^8.5.2",
     "lucide-react": "^0.475.0",
     "next": "15.1.6",
     "react": "^19.0.0",

--- a/nefac-website/src/App.tsx
+++ b/nefac-website/src/App.tsx
@@ -11,13 +11,13 @@ const App = () => {
   return (
     <>
     <Header />
-        <Router>
-      <Routes>
-        <Route path="/" element={<Home />} />
-        <Route path="/nefac-news" element={<NewsPage />} />
-        <Route path="/sustaining-memberships" element={<SustainingMembershipsPage />} />
-      </Routes>
-    </Router>
+      <Router>
+        <Routes>
+          <Route path="/" element={<Home />} />
+          <Route path="/nefac-news" element={<NewsPage />} />
+          <Route path="/sustaining-memberships" element={<SustainingMembershipsPage />} />
+        </Routes>
+      </Router>
     </>
   );
 

--- a/nefac-website/src/App.tsx
+++ b/nefac-website/src/App.tsx
@@ -5,14 +5,15 @@ import SustainingMembershipsPage from "./pages/sustaining-memberships/page";
 import NewsPage from "./pages/nefac-news/page";
 import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 import Header from "./components/header";
+import Home from "./app/page";
 
 const App = () => {
-
   return (
     <>
     <Header />
         <Router>
       <Routes>
+        <Route path="/" element={<Home />} />
         <Route path="/nefac-news" element={<NewsPage />} />
         <Route path="/sustaining-memberships" element={<SustainingMembershipsPage />} />
       </Routes>

--- a/nefac-website/src/app/page.tsx
+++ b/nefac-website/src/app/page.tsx
@@ -1,5 +1,6 @@
-import Bubble from "./components/bubble";
-import Header from "./components/header";
+import Bubble from "../components/Bubble";
+import Header from "../components/header";
+import CommentarySection from "@/components/CommentarySection";
 
 export default function Home() {
   return (
@@ -38,7 +39,9 @@ export default function Home() {
             style="bg-nefacblue text-white text-4xl text-bold w-1/4 h-1/3 leading-[50px] p-6"
           />
         </div>
+        <CommentarySection />
       </div>
     </div>
   );
 }
+

--- a/nefac-website/src/app/page.tsx
+++ b/nefac-website/src/app/page.tsx
@@ -5,9 +5,6 @@ import CommentarySection from "@/components/CommentarySection";
 export default function Home() {
   return (
     <div className="px-36 pt-12 flex flex-row flex-wrap gap-4">
-      <div className="z-10">
-        <Header />
-      </div>
       <div className="z-0">
         <Bubble
           title="NEFAC, Mass. Open Government Groups: Governor’s Proposal Will Close the Open Meeting Law"

--- a/nefac-website/src/components/ArticleCard.tsx
+++ b/nefac-website/src/components/ArticleCard.tsx
@@ -1,0 +1,35 @@
+interface ArticleCardProps {
+  thumbnailUrl: string;
+  title: string;
+  summary: string;
+  articleUrl: string;
+}
+
+const ArticleCard = ({ thumbnailUrl, title, summary, articleUrl }: ArticleCardProps) => {
+  return (
+    <a 
+      href={articleUrl} 
+      className="block w-5/6 bg-white rounded-xl shadow-xl overflow-hidden hover:shadow-2xl transition-shadow duration-300 flex flex-col h-full mx-auto"
+    >
+      <div className="flex flex-col flex-grow">
+        <div className="h-60 p-6 mb-4">
+          <img
+            className="w-full h-60 object-cover rounded-xl"
+            src={thumbnailUrl}
+            alt={`${title} thumbnail`}
+          />
+        </div>
+        <div className="p-6 flex-grow">
+          <h2 className="block text-[20px] leading-tight font-bold text-black">
+            {title}
+          </h2>
+          <p className="mt-2 text-black text-[16px]">
+            {summary}
+          </p>
+        </div>
+      </div>
+    </a>
+  );
+};
+
+export default ArticleCard;

--- a/nefac-website/src/components/ArticleCardCarousel.tsx
+++ b/nefac-website/src/components/ArticleCardCarousel.tsx
@@ -1,0 +1,47 @@
+import ArticleCard from './ArticleCard';
+import {
+  Carousel,
+  CarouselContent,
+  CarouselItem,
+  CarouselNext,
+  CarouselPrevious,
+} from "@/components/ui/carousel";
+
+interface Article {
+  thumbnailUrl: string;
+  title: string;
+  summary: string;
+  articleUrl: string;
+}
+
+interface ArticleCardCarouselProps {
+  articles: Article[];
+}
+
+const ArticleCardCarousel = ({ articles }: ArticleCardCarouselProps) => {
+  return (
+    <Carousel className="w-full py-4 mb-8">
+      <CarouselContent className="flex">
+        {articles.map((article, i) => (
+          <CarouselItem 
+            key={i}
+            className="basis-full md:basis-1/2 flex p-2"
+          >
+            <div className="w-full flex flex-col h-full">
+              <ArticleCard
+                thumbnailUrl={article.thumbnailUrl}
+                title={article.title}
+                summary={article.summary}
+                articleUrl={article.articleUrl}
+              />
+            </div>
+          </CarouselItem>
+        ))}
+      </CarouselContent>
+      <CarouselPrevious />
+      <CarouselNext />
+    </Carousel>
+  )
+};
+
+export default ArticleCardCarousel;

--- a/nefac-website/src/components/CommentarySection.tsx
+++ b/nefac-website/src/components/CommentarySection.tsx
@@ -1,0 +1,40 @@
+import ArticleCardCarousel from "@/components/ArticleCardCarousel";
+
+// placeholder content
+const articles = [
+    {
+        thumbnailUrl: "/public/images/computer.png",
+        title: "Roped-Off R.I. State House Rotunda Seen as Part of ‘Playbook’ for Muting Dissent",
+        summary: "Over the years, government officials and politicians have established so-called “First Amendment areas” at political conventions and others events, NEFAC Executive Director Justin Silverman said. “Often they are a very restricted area with limited visibility,” he said. “The purpose is typically to make sure that protesters are not seen and heard and do not cause any kind of disturbance or embarrassment for the organizers for the event.”",
+        articleUrl: "https://google.com"
+    },
+    {
+        thumbnailUrl: "/public/images/computer.png",
+        title: "Police Heavily Redact Records From Two Domestic Violence Calls Made Just Days Before a Double Homicide",
+        summary: "Police cited privacy concerns as the primary reason for the redactions, but in this case, everyone involved is dead. “The privacy interest there just doesn’t exist,” NEFAC’s Justin Silverman recently told WMTW. “So, all we have is secrecy on behalf of the police department as far as how the investigation occurred, what was investigated, and how, and we’re left wondering, was there an opportunity to prevent this tragedy in the first place?”",
+        articleUrl: "https://google.com"
+    },
+    {
+        thumbnailUrl: "/public/images/computer.png",
+        title: "foobar",
+        summary: "summary",
+        articleUrl: "https://google.com"
+    }
+]
+
+export default function CommentarySection() {
+    return (
+        <div className="flex flex-col gap-4 pt-4 h-100 bg-nefacblue p-6 relative">
+            <div className="flex items-center">
+                <h2 className="text-white font-bold text-3xl">Commentary</h2>
+                <div className="flex-grow h-2 bg-white translate-x-6 rounded-l-full"></div>
+            </div>
+            <ArticleCardCarousel articles={articles} />
+            <div className="absolute bottom-0 left-1/2 transform -translate-x-1/2 translate-y-1/2">
+                <a href="#" className="bg-white text-nefacblue p-4 rounded-md border-[7px] font-semibold border-nefacblue hover:border-white hover:bg-nefacblue hover:text-white transition-colors duration-300">
+                    Learn more about Commentary
+                </a>
+            </div>
+        </div>
+    )
+}

--- a/nefac-website/src/components/ui/button.tsx
+++ b/nefac-website/src/components/ui/button.tsx
@@ -1,0 +1,56 @@
+import * as React from "react"
+import { Slot } from "@radix-ui/react-slot"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const buttonVariants = cva(
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary text-primary-foreground hover:bg-primary/90",
+        destructive:
+          "bg-destructive text-destructive-foreground hover:bg-destructive/90",
+        outline:
+          "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
+        secondary:
+          "bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        ghost: "hover:bg-accent hover:text-accent-foreground",
+        link: "text-primary underline-offset-4 hover:underline",
+      },
+      size: {
+        default: "h-10 px-4 py-2",
+        sm: "h-9 rounded-md px-3",
+        lg: "h-11 rounded-md px-8",
+        icon: "h-10 w-10",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+)
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {
+  asChild?: boolean
+}
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, size, asChild = false, ...props }, ref) => {
+    const Comp = asChild ? Slot : "button"
+    return (
+      <Comp
+        className={cn(buttonVariants({ variant, size, className }))}
+        ref={ref}
+        {...props}
+      />
+    )
+  }
+)
+Button.displayName = "Button"
+
+export { Button, buttonVariants }

--- a/nefac-website/src/components/ui/carousel.tsx
+++ b/nefac-website/src/components/ui/carousel.tsx
@@ -1,0 +1,262 @@
+"use client"
+
+import * as React from "react"
+import useEmblaCarousel, {
+  type UseEmblaCarouselType,
+} from "embla-carousel-react"
+import { ArrowLeft, ArrowRight } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+
+type CarouselApi = UseEmblaCarouselType[1]
+type UseCarouselParameters = Parameters<typeof useEmblaCarousel>
+type CarouselOptions = UseCarouselParameters[0]
+type CarouselPlugin = UseCarouselParameters[1]
+
+type CarouselProps = {
+  opts?: CarouselOptions
+  plugins?: CarouselPlugin
+  orientation?: "horizontal" | "vertical"
+  setApi?: (api: CarouselApi) => void
+}
+
+type CarouselContextProps = {
+  carouselRef: ReturnType<typeof useEmblaCarousel>[0]
+  api: ReturnType<typeof useEmblaCarousel>[1]
+  scrollPrev: () => void
+  scrollNext: () => void
+  canScrollPrev: boolean
+  canScrollNext: boolean
+} & CarouselProps
+
+const CarouselContext = React.createContext<CarouselContextProps | null>(null)
+
+function useCarousel() {
+  const context = React.useContext(CarouselContext)
+
+  if (!context) {
+    throw new Error("useCarousel must be used within a <Carousel />")
+  }
+
+  return context
+}
+
+const Carousel = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement> & CarouselProps
+>(
+  (
+    {
+      orientation = "horizontal",
+      opts,
+      setApi,
+      plugins,
+      className,
+      children,
+      ...props
+    },
+    ref
+  ) => {
+    const [carouselRef, api] = useEmblaCarousel(
+      {
+        ...opts,
+        axis: orientation === "horizontal" ? "x" : "y",
+      },
+      plugins
+    )
+    const [canScrollPrev, setCanScrollPrev] = React.useState(false)
+    const [canScrollNext, setCanScrollNext] = React.useState(false)
+
+    const onSelect = React.useCallback((api: CarouselApi) => {
+      if (!api) {
+        return
+      }
+
+      setCanScrollPrev(api.canScrollPrev())
+      setCanScrollNext(api.canScrollNext())
+    }, [])
+
+    const scrollPrev = React.useCallback(() => {
+      api?.scrollPrev()
+    }, [api])
+
+    const scrollNext = React.useCallback(() => {
+      api?.scrollNext()
+    }, [api])
+
+    const handleKeyDown = React.useCallback(
+      (event: React.KeyboardEvent<HTMLDivElement>) => {
+        if (event.key === "ArrowLeft") {
+          event.preventDefault()
+          scrollPrev()
+        } else if (event.key === "ArrowRight") {
+          event.preventDefault()
+          scrollNext()
+        }
+      },
+      [scrollPrev, scrollNext]
+    )
+
+    React.useEffect(() => {
+      if (!api || !setApi) {
+        return
+      }
+
+      setApi(api)
+    }, [api, setApi])
+
+    React.useEffect(() => {
+      if (!api) {
+        return
+      }
+
+      onSelect(api)
+      api.on("reInit", onSelect)
+      api.on("select", onSelect)
+
+      return () => {
+        api?.off("select", onSelect)
+      }
+    }, [api, onSelect])
+
+    return (
+      <CarouselContext.Provider
+        value={{
+          carouselRef,
+          api: api,
+          opts,
+          orientation:
+            orientation || (opts?.axis === "y" ? "vertical" : "horizontal"),
+          scrollPrev,
+          scrollNext,
+          canScrollPrev,
+          canScrollNext,
+        }}
+      >
+        <div
+          ref={ref}
+          onKeyDownCapture={handleKeyDown}
+          className={cn("relative", className)}
+          role="region"
+          aria-roledescription="carousel"
+          {...props}
+        >
+          {children}
+        </div>
+      </CarouselContext.Provider>
+    )
+  }
+)
+Carousel.displayName = "Carousel"
+
+const CarouselContent = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => {
+  const { carouselRef, orientation } = useCarousel()
+
+  return (
+    <div ref={carouselRef} className="overflow-hidden">
+      <div
+        ref={ref}
+        className={cn(
+          "flex",
+          orientation === "horizontal" ? "-ml-4" : "-mt-4 flex-col",
+          className
+        )}
+        {...props}
+      />
+    </div>
+  )
+})
+CarouselContent.displayName = "CarouselContent"
+
+const CarouselItem = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => {
+  const { orientation } = useCarousel()
+
+  return (
+    <div
+      ref={ref}
+      role="group"
+      aria-roledescription="slide"
+      className={cn(
+        "min-w-0 shrink-0 grow-0 basis-full",
+        orientation === "horizontal" ? "pl-4" : "pt-4",
+        className
+      )}
+      {...props}
+    />
+  )
+})
+CarouselItem.displayName = "CarouselItem"
+
+const CarouselPrevious = React.forwardRef<
+  HTMLButtonElement,
+  React.ComponentProps<typeof Button>
+>(({ className, variant = "outline", size = "icon", ...props }, ref) => {
+  const { orientation, scrollPrev, canScrollPrev } = useCarousel()
+
+  return (
+    <Button
+      ref={ref}
+      variant={variant}
+      size={size}
+      className={cn(
+        "absolute  h-8 w-8 rounded-full",
+        orientation === "horizontal"
+          ? "-left-8 top-1/2 -translate-y-1/2"
+          : "-top-12 left-1/2 -translate-x-1/2 rotate-90",
+        className
+      )}
+      disabled={!canScrollPrev}
+      onClick={scrollPrev}
+      {...props}
+    >
+      <ArrowLeft className="h-4 w-4" />
+      <span className="sr-only">Previous slide</span>
+    </Button>
+  )
+})
+CarouselPrevious.displayName = "CarouselPrevious"
+
+const CarouselNext = React.forwardRef<
+  HTMLButtonElement,
+  React.ComponentProps<typeof Button>
+>(({ className, variant = "outline", size = "icon", ...props }, ref) => {
+  const { orientation, scrollNext, canScrollNext } = useCarousel()
+
+  return (
+    <Button
+      ref={ref}
+      variant={variant}
+      size={size}
+      className={cn(
+        "absolute h-8 w-8 rounded-full",
+        orientation === "horizontal"
+          ? "-right-8 top-1/2 -translate-y-1/2"
+          : "-bottom-12 left-1/2 -translate-x-1/2 rotate-90",
+        className
+      )}
+      disabled={!canScrollNext}
+      onClick={scrollNext}
+      {...props}
+    >
+      <ArrowRight className="h-4 w-4" />
+      <span className="sr-only">Next slide</span>
+    </Button>
+  )
+})
+CarouselNext.displayName = "CarouselNext"
+
+export {
+  type CarouselApi,
+  Carousel,
+  CarouselContent,
+  CarouselItem,
+  CarouselPrevious,
+  CarouselNext,
+}


### PR DESCRIPTION
Closes #19

- Used ShadCN carousel component
- Added ArticleCard component to represent a single article card
- Added ArticleCardCarousel as a wrapper around the ShadCN component that populates the content
- Added CommentarySection for the actual commentary section on the homepage (contains some mock content which should be removed later)

My branch is somewhat outdated, so stuff might need to be moved around a bit. Once this is merged I will abstract/generalize these components further to be used with some of the other similar tickets. 

I also think the spacing isn't perfect, and it's tricky to get the left/right buttons from ShadCN to properly fit within the page boundaries... if anyone else can help with those minor details that would be great!

| Implementation | Figma |
| -------- | ----------- |
| ![image](https://github.com/user-attachments/assets/0779567b-fa11-45e0-b984-b89f37e7d323) | ![image](https://github.com/user-attachments/assets/61dbb5c9-7e18-4a56-9db5-b614868b4a38) |
