### PR TITLE
Generalize carousels, implement Community & Advocacy sections

### DIFF
--- a/nefac-website/src/app/components/AdvocacySection.tsx
+++ b/nefac-website/src/app/components/AdvocacySection.tsx
@@ -1,0 +1,42 @@
+import ArticleCardCarousel from "./ArticleCardCarousel";
+
+const articles = [
+  {
+    thumbnailUrl: "/public/images/filler.jpeg",
+    title: "NEFAC, Vermont Press Association Defend Right to Record in Milton",
+    summary: "The Milton Library Board of Trustees had planned to discuss a possible policy that would prohibit attendees of its meetings from recording. NEFAC and the Vermont Press Association sent a letter to Board Chair Alan Fletcher on Nov. 14 and explained that “recording is not just legally protected but it’s encouraged under the law.",
+    articleUrl: "#",
+  },
+  {
+    thumbnailUrl: "/public/images/filler.jpeg",
+    title: "NEFAC: Access to Massachusetts Courts Limited By Inoperable, Overused Public Terminals",
+    summary: "“Due to a combination of out-of-service kiosks and individuals using kiosks for an unreasonable amount of time, public access can frequently be denied. This is a major concern given that many court records, such as documents in criminal cases, cannot be thoroughly researched remotely but must instead be searched for through these kiosks.”",
+    articleUrl: "#",
+  },
+  {
+    thumbnailUrl: "/public/images/filler.jpeg",
+    title: "NEFAC: Access to Massachusetts Courts Limited By Inoperable, Overused Public Terminals",
+    summary: "“Due to a combination of out-of-service kiosks and individuals using kiosks for an unreasonable amount of time, public access can frequently be denied. This is a major concern given that many court records, such as documents in criminal cases, cannot be thoroughly researched remotely but must instead be searched for through these kiosks.”",
+    articleUrl: "#",
+  },
+];
+
+export default function AdvocacySection() {
+  return (
+    <div className="flex flex-col gap-4 pt-4 h-100 bg-nefacblue p-12 relative">
+      <div className="flex items-center">
+        <h2 className="text-white font-bold text-3xl">Advocacy</h2>
+        <div className="flex-grow h-2 bg-white translate-x-12 rounded-l-full" />
+      </div>
+
+      <ArticleCardCarousel articles={articles} slidesPerView={3} showControls={false} />
+
+      <a
+        href="#"
+        className="absolute bottom-0 left-1/2 -translate-x-1/2 translate-y-1/2 bg-white text-nefacblue p-4 rounded-md border-[7px] font-semibold border-nefacblue hover:border-white hover:bg-nefacblue hover:text-white transition-colors duration-300"
+      >
+        Learn more about Advocacy
+      </a>
+    </div>
+  );
+}

--- a/nefac-website/src/app/components/ArticleCard.tsx
+++ b/nefac-website/src/app/components/ArticleCard.tsx
@@ -23,7 +23,7 @@ const ArticleCard = ({ thumbnailUrl, title, summary, articleUrl }: ArticleCardPr
           <h2 className="block text-[20px] leading-tight font-bold text-black">
             {title}
           </h2>
-          <p className="mt-2 text-black text-[16px]">
+          <p className="mt-2 text-black text-[14px]">
             {summary}
           </p>
         </div>

--- a/nefac-website/src/app/components/ArticleCardCarousel.tsx
+++ b/nefac-website/src/app/components/ArticleCardCarousel.tsx
@@ -1,12 +1,5 @@
 import ArticleCard from './ArticleCard';
-import {
-  Carousel,
-  CarouselContent,
-  CarouselItem,
-  CarouselNext,
-  CarouselPrevious,
-} from "@/app/components/ui/carousel";
-
+import CardCarousel from './CardCarousel';
 interface Article {
   thumbnailUrl: string;
   title: string;
@@ -16,31 +9,22 @@ interface Article {
 
 interface ArticleCardCarouselProps {
   articles: Article[];
+  showControls?: boolean;
+  slidesPerView?: number;
 }
 
-const ArticleCardCarousel = ({ articles }: ArticleCardCarouselProps) => {
+const ArticleCardCarousel = ({ articles, showControls, slidesPerView }: ArticleCardCarouselProps) => {
   return (
-    <Carousel className="w-full py-4 mb-8">
-      <CarouselContent className="flex">
-        {articles.map((article, i) => (
-          <CarouselItem 
-            key={i}
-            className="basis-full md:basis-1/2 flex p-2"
-          >
-            <div className="w-full flex flex-col h-full">
-              <ArticleCard
-                thumbnailUrl={article.thumbnailUrl}
-                title={article.title}
-                summary={article.summary}
-                articleUrl={article.articleUrl}
-              />
-            </div>
-          </CarouselItem>
-        ))}
-      </CarouselContent>
-      <CarouselPrevious />
-      <CarouselNext />
-    </Carousel>
+    <CardCarousel
+      items={articles}
+      renderItem={(article) => (
+        <div className="w-full flex flex-col h-full">
+          <ArticleCard {...article} />
+        </div>
+      )}
+      showControls={showControls}
+      slidesPerView={slidesPerView}
+    />
   )
 };
 

--- a/nefac-website/src/app/components/CardCarousel.tsx
+++ b/nefac-website/src/app/components/CardCarousel.tsx
@@ -1,0 +1,47 @@
+import {
+  Carousel,
+  CarouselContent,
+  CarouselItem,
+  CarouselNext,
+  CarouselPrevious,
+} from "@/app/components/ui/carousel";
+
+interface CardCarouselProps<T> {
+  items: T[];
+  renderItem: (item: T) => React.ReactNode;
+  carouselItemClass?: string;
+  showControls?: boolean;
+  slidesPerView?: number;
+}
+
+const CardCarousel = <T,>({ 
+  items, 
+  renderItem,
+  carouselItemClass = "basis-full flex py-2 px-1/4 flex-shrink-0",
+  showControls = true,
+  slidesPerView = 2  // Default to 2 cards
+}: CardCarouselProps<T>) => {
+  return (
+    <Carousel className="w-full py-4 mb-8">
+      <CarouselContent className="flex">
+        {items.map((item, i) => (
+          <CarouselItem 
+            key={i} 
+            className={carouselItemClass}
+            style={{flexBasis: `calc(100%/${slidesPerView})`}}
+          >
+            {renderItem(item)}
+          </CarouselItem>
+        ))}
+      </CarouselContent>
+      {showControls && (
+        <>
+          <CarouselPrevious />
+          <CarouselNext />
+        </>
+      )}
+    </Carousel>
+  );
+};
+
+export default CardCarousel;

--- a/nefac-website/src/app/components/CommentarySection.tsx
+++ b/nefac-website/src/app/components/CommentarySection.tsx
@@ -4,13 +4,13 @@ const articles = [
   {
     thumbnailUrl: "/public/images/computer.png",
     title: "Roped-Off R.I. State House Rotunda Seen as Part of ‘Playbook’ for Muting Dissent",
-    summary: "Over the years, government officials and politicians have established so-called “First Amendment areas” at political conventions and others events, NEFAC Executive Director Justin Silverman said. “Often they are a very restricted area with limited visibility,” he said...",
+    summary: "Over the years, government officials and politicians have established so-called “First Amendment areas” at political conventions and others events, NEFAC Executive Director Justin Silverman said. “Often they are a very restricted area with limited visibility,” he said. “The purpose is typically to make sure that protesters are not seen and heard and do not cause any kind of disturbance or embarrassment for the organizers for the event.”",
     articleUrl: "https://google.com",
   },
   {
     thumbnailUrl: "/public/images/computer.png",
     title: "Police Heavily Redact Records From Two Domestic Violence Calls...",
-    summary: "Police cited privacy concerns as the primary reason for the redactions, but in this case, everyone involved is dead. “The privacy interest there just doesn’t exist,” NEFAC’s Justin Silverman recently told WMTW...",
+    summary: "Police cited privacy concerns as the primary reason for the redactions, but in this case, everyone involved is dead. “The privacy interest there just doesn’t exist,” NEFAC’s Justin Silverman recently told WMTW. “So, all we have is secrecy on behalf of the police department as far as how the investigation occurred, what was investigated, and how, and we’re left wondering, was there an opportunity to prevent this tragedy in the first place?”",
     articleUrl: "https://google.com",
   },
   {
@@ -23,10 +23,10 @@ const articles = [
 
 export default function CommentarySection() {
   return (
-    <div className="flex flex-col gap-4 pt-4 h-100 bg-nefacblue p-6 relative">
+    <div className="flex flex-col gap-4 pt-4 h-100 bg-nefacblue p-12 relative">
       <div className="flex items-center">
         <h2 className="text-white font-bold text-3xl">Commentary</h2>
-        <div className="flex-grow h-2 bg-white translate-x-6 rounded-l-full" />
+        <div className="flex-grow h-2 bg-white translate-x-12 rounded-l-full" />
       </div>
 
       <ArticleCardCarousel articles={articles} />

--- a/nefac-website/src/app/components/CommunitySection.tsx
+++ b/nefac-website/src/app/components/CommunitySection.tsx
@@ -1,0 +1,49 @@
+import ArticleCardCarousel from "./ArticleCardCarousel";
+
+const communityArticles = [
+  {
+    thumbnailUrl: "/public/images/computer.png",
+    title: "30 Minute Skills: Business Reporting 101",
+    summary: "All journalists — whatever the beat — should think of themselves as business journalists. By viewing this class, you’ll learn (1) how to begin a business beat or start incorporating business journalism practices into your current beat (2) where to find stories and sources and (3) how to localize national and global business stories.",
+    articleUrl: "#",
+  },
+  {
+    thumbnailUrl: "/public/images/computer.png",
+    title: "NEFAC Discusses Journalism, First Amendment to Lebanese and African Delegations",
+    summary: "“Due to a combination of out-of-service kiosks and individuals using kiosks for an unreasonable amount of time, public access can frequently be denied. This is a major concern given that many court records, such as documents in criminal cases, cannot be thoroughly researched remotely but must instead be searched for through these kiosks.”",
+    articleUrl: "#",
+  },
+  {
+    thumbnailUrl: "/public/images/computer.png",
+    title: "30 Minute Skills: Copyright Law 102",
+    summary: "Copyright law can be a complex and nuanced area for journalists and non-journalists alike. Questions of ownership, fair use and other intellectual property concerns are especially relevant to newsgathering as more information is found through social media and other online sources. This is the second of two classes introducing copyright law and suggesting best practices. View the first class here. ",
+    articleUrl: "#",
+  }
+];
+
+export default function CommunitySection() {
+  return (
+    <div className="flex flex-col gap-4 pt-6 my-12 h-100 bg-nefacblue ml-12 pr-12 relative rounded-l-3xl">
+      <div className="flex items-center pl-6">
+        <h2 className="text-white font-bold text-3xl">Community</h2>
+      </div>
+
+      <div className="pr-6 flex justify-end -mt-4 -mb-6 mr-4">
+        <a 
+          href="#"
+          className="text-white hover:underline transition-colors duration-300"
+        >
+          More Community News {'>'}
+        </a>
+      </div>
+
+      <div className="pl-4">
+        <ArticleCardCarousel 
+            articles={communityArticles} 
+            showControls={false}  // Hide navigation buttons
+            slidesPerView={3}
+        />
+      </div>
+    </div>
+  );
+}

--- a/nefac-website/src/app/page.tsx
+++ b/nefac-website/src/app/page.tsx
@@ -1,12 +1,15 @@
-import CommentarySection from "../app/components/CommentarySection";
+import AdvocacySection from "./components/AdvocacySection";
+import CommentarySection from "./components/CommentarySection";
+import CommunitySection from "./components/CommunitySection";
 
 export default function Home() {
   return (
     <div className="px-36 pt-12 flex flex-row flex-wrap gap-4">
       <div className="z-0 pb-20">
         <CommentarySection />
+        <CommunitySection />
+        <AdvocacySection />
       </div>
     </div>
   );
 }
-


### PR DESCRIPTION
Closes #23 and #24

- Created a wrapper component around ShadCN carousels called CardCarousel
- Updated ArticleCarousel
- Added Community and Advocacy section components and added to homepage

Also, defined ArticleCard in a previous PR which is basically just the standalone component for a card that represents some article (thumbnail + title + summary) if it's relevant for any other tasks

Also note that the all-caps title for Advocacy section in the Figma was intended to be regular capitalization according to the designers

| Issue | Figma | Implementation |
| ------ | ------ | -------------------|
| #23 | <img width="505" alt="416859703-6e2713aa-8993-4eb3-b184-1d39ecdee038" src="https://github.com/user-attachments/assets/d8bd0793-2a52-4452-a9fc-80c226b39b32" /> | <img width="505" src="https://github.com/user-attachments/assets/21b99ce8-008f-45b5-8024-58d2fc88526d" /> |
| #24 | <img width="501" alt="416859998-e2f88e90-3185-4a6c-b22f-2ebf0ed29fdc" src="https://github.com/user-attachments/assets/9d0ec0e8-4c09-496a-9270-27398a43f1fc" /> | <img src="https://github.com/user-attachments/assets/e8bdf700-0c21-4c65-907c-02c7cd2c1dc9" width="501" /> |