### PR TITLE
Issue #49 - education initiative template

### DIFF
--- a/nefac-website/src/App.tsx
+++ b/nefac-website/src/App.tsx
@@ -9,6 +9,7 @@ import MissionPage from "./app/pages/mission/page";
 import Home from "./app/page";
 import LeadershipPage from "./app/pages/leadership/leader-page";
 import SubscribePage from "./app/pages/subscribe/page";
+import EducationInitiativePage from "./app/components/education-initiative-page/EducationInitiativePage";
 
 const App = () => {
   return (
@@ -21,6 +22,7 @@ const App = () => {
         <Route path="/mission" element={<MissionPage />} />
         <Route path="/leadership" element={<LeadershipPage />} />
         <Route path="/subscribe" element={<SubscribePage />} />
+        <Route path="/education-initiative" element={<EducationInitiativePage initDescSect={true} upcomingPresSection={true} pastPresSection={true} />} />
       </Routes>
       <Footer />
     </BrowserRouter>

--- a/nefac-website/src/app/components/education-initiative-page/EducationInitiativePage.tsx
+++ b/nefac-website/src/app/components/education-initiative-page/EducationInitiativePage.tsx
@@ -1,4 +1,3 @@
-import { init } from "next/dist/compiled/webpack/webpack";
 import InitiativeDescription from "./InitiativeDescription";
 import Sidebar from "./Sidebar";
 
@@ -8,26 +7,25 @@ interface EducationInitiativePageProps {
     pastPresSection: boolean;
 }
 
-
-
-// Single page of education initiative component. Take in the boolean components accordingly
-// Page will need to be abstracted later so that it uses WordPress API to get the actual information, should it exist
+// Single page of education initiative component
+// Page will later need to be updated to use the WordPress API to get the actual information
 export default function EducationInitiativePage({
+    // Parameters for what sections of the page should exist
     initDescSect,
     upcomingPresSection,
     pastPresSection
 }: EducationInitiativePageProps) {
     return (
-        <div>
+        <div className="min-h-screen">
             <div className="text-nefacblue text-[36px] font-bold px-8">
                 Education Initiatives
             </div>
-            <div className="flex flex-row gap-10">
+            <div className="w-full flex flex-row gap-10">
                 <Sidebar />
-                <div className="flex flex-col">
+                <div className="w-full flex flex-col">
                     {initDescSect && (
                     <InitiativeDescription 
-                        header = "This is the Header Portoin"
+                        header = "This is the Header Portion"
                         description="Testing text for the First Amendment and Free Press Education Initiative.
                         Testing text for the First Amendment and Free Press Education Initiative.
                         Testing text for the First Amendment and Free Press Education Initiative.
@@ -39,8 +37,9 @@ export default function EducationInitiativePage({
                         thumbnailUrl="https://gw-advance-prod-us-east-1-system.s3.amazonaws.com/uploads/campaign_image/name/6220f528cabcde2023b2a543/8d7e7465-97b6-461a-a141-66ddeb535b7b.jpeg"
                     />
                     )}
+                    {/* TODO: Replace this with the abstract components from tickets 50 and 51 */}
                     {upcomingPresSection && (
-                    <div className="text-[100px]">
+                    <div className="w-full text-[32px]">
                         Upcoming Presentations Section Display Text.
                         Upcoming Presentations Section Display Text.
                         Upcoming Presentations Section Display Text.
@@ -49,7 +48,7 @@ export default function EducationInitiativePage({
                     </div>
                     )}
                     {pastPresSection && (
-                    <div className="text-[100px]">
+                    <div className="w-full text-[32px]">
                         Past Presentations Section Display Text
                     </div>
                     )}

--- a/nefac-website/src/app/components/education-initiative-page/EducationInitiativePage.tsx
+++ b/nefac-website/src/app/components/education-initiative-page/EducationInitiativePage.tsx
@@ -1,0 +1,60 @@
+import { init } from "next/dist/compiled/webpack/webpack";
+import InitiativeDescription from "./InitiativeDescription";
+import Sidebar from "./Sidebar";
+
+interface EducationInitiativePageProps {
+    initDescSect: boolean;
+    upcomingPresSection: boolean;
+    pastPresSection: boolean;
+}
+
+
+
+// Single page of education initiative component. Take in the boolean components accordingly
+// Page will need to be abstracted later so that it uses WordPress API to get the actual information, should it exist
+export default function EducationInitiativePage({
+    initDescSect,
+    upcomingPresSection,
+    pastPresSection
+}: EducationInitiativePageProps) {
+    return (
+        <div>
+            <div className="text-nefacblue text-[36px] font-bold px-8">
+                Education Initiatives
+            </div>
+            <div className="flex flex-row gap-10">
+                <Sidebar />
+                <div className="flex flex-col">
+                    {initDescSect && (
+                    <InitiativeDescription 
+                        header = "This is the Header Portoin"
+                        description="Testing text for the First Amendment and Free Press Education Initiative.
+                        Testing text for the First Amendment and Free Press Education Initiative.
+                        Testing text for the First Amendment and Free Press Education Initiative.
+                        Testing text for the First Amendment and Free Press Education Initiative.
+                        Testing text for the First Amendment and Free Press Education Initiative.
+                        Testing text for the First Amendment and Free Press Education Initiative.
+                        Testing text for the First Amendment and Free Press Education Initiative.
+                        Testing text for the First Amendment and Free Press Education Initiative."
+                        thumbnailUrl="https://gw-advance-prod-us-east-1-system.s3.amazonaws.com/uploads/campaign_image/name/6220f528cabcde2023b2a543/8d7e7465-97b6-461a-a141-66ddeb535b7b.jpeg"
+                    />
+                    )}
+                    {upcomingPresSection && (
+                    <div className="text-[100px]">
+                        Upcoming Presentations Section Display Text.
+                        Upcoming Presentations Section Display Text.
+                        Upcoming Presentations Section Display Text.
+                        Upcoming Presentations Section Display Text.
+                        Upcoming Presentations Section Display Text.
+                    </div>
+                    )}
+                    {pastPresSection && (
+                    <div className="text-[100px]">
+                        Past Presentations Section Display Text
+                    </div>
+                    )}
+                </div>
+            </div>
+        </div>
+    )
+}

--- a/nefac-website/src/app/components/education-initiative-page/InitiativeDescription.tsx
+++ b/nefac-website/src/app/components/education-initiative-page/InitiativeDescription.tsx
@@ -10,20 +10,21 @@ export default function InitiativeDescription({
     thumbnailUrl,
 }: InitiativeDescriptionProps) {
     return (
-        <div className="flex flex-row w-full">
-            <div className="w-[60%]">
-                <div className="text-blue-900 text-[32px]">
+        <div className="flex flex-col sm:flex-row w-full">
+            <div className="w-full sm:w-[60%]">
+                <div className="text-blue-900 text-2xl sm:text-3xl font-semibold mb-2">
                     {header}
                 </div>
-                <div className="text-[16px]">
+                <div className="text-base sm:text-lg">
                     {description}
                 </div>
             </div>
+
             <img
                 src={thumbnailUrl}
-                className="rounded-3xl w-[30%] object-cover items-center justify-center ml-4 mb-4"
                 alt="Education Initiative Thumbnail Image"
+                className="w-full sm:w-[40%] max-w-[400px] h-auto object-cover rounded-3xl"
             />
         </div>
-    )
+    );
 }

--- a/nefac-website/src/app/components/education-initiative-page/InitiativeDescription.tsx
+++ b/nefac-website/src/app/components/education-initiative-page/InitiativeDescription.tsx
@@ -1,0 +1,29 @@
+interface InitiativeDescriptionProps {
+    header: string;
+    description: string;
+    thumbnailUrl: string;
+}
+
+export default function InitiativeDescription({
+    header,
+    description,
+    thumbnailUrl,
+}: InitiativeDescriptionProps) {
+    return (
+        <div className="flex flex-row w-full">
+            <div className="w-[60%]">
+                <div className="text-blue-900 text-[32px]">
+                    {header}
+                </div>
+                <div className="text-[16px]">
+                    {description}
+                </div>
+            </div>
+            <img
+                src={thumbnailUrl}
+                className="rounded-3xl w-[30%] object-cover items-center justify-center ml-4 mb-4"
+                alt="Education Initiative Thumbnail Image"
+            />
+        </div>
+    )
+}

--- a/nefac-website/src/app/components/education-initiative-page/Sidebar.tsx
+++ b/nefac-website/src/app/components/education-initiative-page/Sidebar.tsx
@@ -1,0 +1,31 @@
+import { useState } from "react";
+
+const items: string[] = [
+  "30-Minute Skill",
+  "First Amendment & Free Press",
+  "FOI Guide",
+  "NEFAC Mentors",
+  "Negri Institute",
+];
+
+export default function Sidebar() {
+  const [initiative, setInitiative] = useState(0);
+
+  return (
+    <div className="sticky top-4 flex shrink-0 py-2 h-fit self-start">
+      <div className="flex flex-col px-4 py-4 gap-2 w-[300px]">
+        {items.map((item, i) => (
+          <div
+            key={i}
+            onClick={() => setInitiative(i)}
+            className={`cursor-pointer px-4 py-2 rounded-r-3xl transition 
+              ${i === initiative ? "bg-gray-100 border-l-4 border-blue-600" : "bg-white"}`}
+          >
+            {item}
+          </div>
+        ))}
+      </div>
+      <div className="w-[3px] h-[300px] bg-gray-200" />
+    </div>
+  );
+}

--- a/nefac-website/src/app/components/education-initiative-page/Sidebar.tsx
+++ b/nefac-website/src/app/components/education-initiative-page/Sidebar.tsx
@@ -10,22 +10,62 @@ const items: string[] = [
 
 export default function Sidebar() {
   const [initiative, setInitiative] = useState(0);
+  const [isOpen, setIsOpen] = useState(false);
 
   return (
-    <div className="sticky top-4 flex shrink-0 py-2 h-fit self-start">
-      <div className="flex flex-col px-4 py-4 gap-2 w-[300px]">
-        {items.map((item, i) => (
-          <div
-            key={i}
-            onClick={() => setInitiative(i)}
-            className={`cursor-pointer px-4 py-2 rounded-r-3xl transition 
-              ${i === initiative ? "bg-gray-100 border-l-4 border-blue-600" : "bg-white"}`}
-          >
-            {item}
-          </div>
-        ))}
+    <>
+      <div className="hidden md:flex sticky top-4 h-fit self-start">
+        <div className="flex flex-col px-4 py-4 gap-2 w-[300px]">
+          {items.map((item, i) => (
+            <div
+              key={i}
+              onClick={() => setInitiative(i)}
+              className={`cursor-pointer px-4 py-2 rounded-r-3xl 
+                ${i === initiative ? "bg-gray-100 border-l-4 border-blue-600" : "bg-white"}`}
+            >
+              {item}
+            </div>
+          ))}
+        </div>
+        <div className="w-[3px] h-[300px] bg-gray-200" />
       </div>
-      <div className="w-[3px] h-[300px] bg-gray-200" />
-    </div>
+
+      
+      {!isOpen && (
+        <div className="sticky top-4 h-fit self-start flex md:hidden items-start gap-2 z-40 bg-white">
+          <button
+            onClick={() => setIsOpen(true)}
+            className="text-2xl font-bold p-2"
+          >
+            &gt;&gt;&gt;
+          </button>
+          <div className="w-[3px] h-[300px] bg-gray-200" />
+        </div>
+      )}
+
+      {isOpen && (
+        <div className="fixed inset-0 bg-white z-50 flex flex-col px-4 py-4">
+          <button
+            onClick={() => setIsOpen(false)}
+            className=" flex justify-end text-6xl font-bold text-black pr-5"
+          >
+            x
+          </button>
+
+          <div className="flex flex-col gap-5 mt-20">
+            {items.map((item, i) => (
+              <div
+                key={i}
+                onClick={() => {setInitiative(i)}}
+                className={`cursor-pointer px-4 py-2 rounded-r-3xl text-3xl 
+                  ${i === initiative ? "bg-gray-100 border-l-4 border-blue-600" : "bg-white"}`}
+              >
+                {item}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </>
   );
 }


### PR DESCRIPTION
Overview:

I created the basic functionality of the education initiaive page. I started off by creating a sidebar component. This component contains some dummy data for now, but has each initiative able to be clicked on (later on we will adjust this to make it actually navigate to a new page). I then created a separate component for the initiative description. This is the aspect of the Figma that contains the initiative's header, a description of it, and the thumbnail URL. Both of these were then combined together to create an abstract component that can be used for the entire page. This can be seen in action under the App.tsx file, where there is a separate route navigation using only this abstracted component to create an entire sample page (it uses dummy date for now which can be replaced after Issue #50 and #51 are finished). I did work to make each component responsive as well, handling shrinking screen sizes to switch from a two-column view and sidebar to a one-column view with a collapsed bar. The sidebar, regardless of screen size, also maintains its position on the screen as the user scrolls down on the website.

Screenshots:
![image](https://github.com/user-attachments/assets/3d267ec2-5959-42c8-812f-393bce40784c)
![image](https://github.com/user-attachments/assets/88352f6f-1c07-440f-96c2-c7cb86723cf6)
![image](https://github.com/user-attachments/assets/8ab98b3b-ea7f-4699-8ecf-b162b5f09612)

Future Work:

This ticket is obviously filled with sample dummy text and sidebar titles, so both of these will need to be edited with accurate data later on. Additionally, we will at some point want to change the sidebar to make it so that, rather than just highlighting the clicked on education initiative, the user is also navigated to the proper page displaying that initiative's information as well (once we figure out what thsoe pages are). Additionally, once both tickets 50 and 51 are finished, assuming they are single abstract components, we can simply add them to these to create a full navigable page with just one single component (in this case, EducationInitiativePage).