### PR TITLE
Faustify News Page

### DIFF
--- a/nefac-website/src/components/news-page/article-interface.tsx
+++ b/nefac-website/src/components/news-page/article-interface.tsx
@@ -1,22 +1,9 @@
-interface WordPressMedia {
-    source_url: string;
-}
-  
 export interface WordPressArticle {
-id: number;
-title: {
-    rendered: string;
-};
-content: {
-    rendered: string;
-};
-excerpt: {
-    rendered: string;
-};
-slug: string;
-date: string;
-featured_media: number;
-_embedded?: {
-    'wp:featuredmedia'?: WordPressMedia[];
-};
+  data: {
+    posts: {
+      nodes: Array<{
+        id: string;
+      }
+    >};
+  }
 }

--- a/nefac-website/src/components/news-page/news-bubble.tsx
+++ b/nefac-website/src/components/news-page/news-bubble.tsx
@@ -1,46 +1,63 @@
 import React from "react";
+import { useQuery, gql } from "@apollo/client";
+import { getNextServerSideProps } from "@faustwp/core";
 
 export interface NewsBubbleProps {
-    image?: string;
-    title?: string;
-    link?: string;
-    date?: string;
+    id?: string;
     header?: boolean;
-    headerPreview?: string;
 }
 
-export const NewsBubble = ({ image, title, link, date, header, headerPreview }: NewsBubbleProps) => {
+export const NewsBubble = ({ id, header }: NewsBubbleProps) => {
+  const { data, loading, error } = useQuery(GET_POST_BY_ID, {
+    variables: { id },
+  });
+
+  const formatDate = (dateString: string) => {
+    const options = { year: "numeric" as const, month: "long" as const, day: "numeric" as const};
+    return new Date(dateString).toLocaleDateString('en-US', options);
+  };
+
+  if (loading) return <div>Loading...</div>;
+  if (error) {
+    console.error("Error loading post:", error);
+    return <div>Error loading post</div>;
+  }
+
+  const post = data?.post;
+  if (!post) return <div>No post found</div>;
     if (header) {
         return (
             <div className="flex flex-row gap-6 mb-6">
-                <a href={link} className="w-3/4 relative">
+                <a href={post.link} className="w-3/4 relative">
                     <div 
                         className="rounded-xl h-full min-h-[400px] bg-cover bg-no-repeat bg-center"
-                        style={{ 
-                            backgroundImage: `linear-gradient(to top, rgba(0,0,0,0.65), rgba(0,0,0,0.0)), url(${image})` 
-                        }}
                     >
                         <div className="absolute flex flex-col bottom-0 text-white font-bold text-2xl p-6 w-2/3">
-                            {title && (
+                            {post.title && (
                                 <h2 
                                     className="mb-2 font-extrabold"
-                                    dangerouslySetInnerHTML={{ __html: title ?? "Title" }}
+                                    dangerouslySetInnerHTML={{ __html: post.title ?? "Title" }}
                                 />
                             )}
-                            {date && (
-                                <p className="font-normal text-[#F8F8F8] text-xs">{date}</p>
+                            {post.date && (
+                                <p className="font-normal text-[#F8F8F8] text-xs">{post.date}</p>
                             )}
                         </div>
                     </div>
                 </a>
                 <div className="w-1/4 flex flex-col">
-                    {headerPreview && headerPreview.split(' ').length > 0 ? (
+                    {post.content && post.content.split(' ').length > 0 ? (
                         <p className="text-base text-[#444444] leading-8 mb-4">
-                            <span className="text-3xl [&>p]:inline" dangerouslySetInnerHTML={{ __html: headerPreview.split(' ')[0] }} />
-                            <span dangerouslySetInnerHTML={{ __html: ' ' + headerPreview.split(' ').slice(1).join(' ') }} />
+                            <span className="text-3xl [&>p]:inline" dangerouslySetInnerHTML=
+                            {{ __html: post.content.match(
+              /<p>(?!<img)(?!<strong>By )(?!<strong>by )(?!by )(?!By )[\s\S]*?<\/p>/i
+            )?.[0].split(' ')[0] || ''}} />
+                            <span dangerouslySetInnerHTML={{ __html: ' ' + post.content.match(
+              /<p>(?!<img)(?!<strong>By )(?!<strong>by )(?!by )(?!By )[\s\S]*?<\/p>/i
+            )?.[0].split(' ').slice(1).join(' ') || '' }} />
                         </p>
                     ) : null}
-                    <a href={link} className="bg-nefacblue text-white rounded-md p-2 text-center font-semibold">
+                    <a href={post.link} className="bg-nefacblue text-white rounded-md p-2 text-center font-semibold">
                         <p>Read More</p>
                     </a>
                 </div>
@@ -48,23 +65,23 @@ export const NewsBubble = ({ image, title, link, date, header, headerPreview }: 
         )
     } else {
         return (
-            <a href={link} className="">
+            <a href={post.link} className="">
                 <div className="relative rounded-xl">
-                {image && (
+                {post.featuredImage && (
                     <img 
-                        src={image}
-                        alt={title ?? "Title"}
+                        src={post.featuredImage.node.sourceUrl}
+                        alt={post.fetauredImage.node.altText ?? "Title"}
                         className="rounded-xl h-[180px] w-full object-cover mb-4"
                     />
                 )}
                     <div className="">
-                        {title && (
+                        {post.title && (
                             <h2 
-                                className="mb-2 font-semibold mb-4">{title ?? "Title"}
+                                className="mb-2 font-semibold mb-4">{post.title ?? "Title"}
                             </h2>
                         )}
-                        {date && (
-                            <p className="font-normal text-[#949494] text-xs">{date}</p>
+                        {post.date && (
+                            <p className="font-normal text-[#949494] text-xs">{formatDate(post.date)}</p>
                         )}
                     </div>
                 </div>
@@ -72,5 +89,27 @@ export const NewsBubble = ({ image, title, link, date, header, headerPreview }: 
         )
     }
 }
+
+const GET_POST_BY_ID = gql`
+  query GetPostById($id: ID!) {
+    post (id: $id, idType: ID) {
+          title
+          author {
+              node {
+                name
+              }
+          }
+          content
+          featuredImage {
+              node {
+                  sourceUrl
+                  altText
+              }
+          }
+          link
+          date
+      }
+  }
+`;
 
 export default NewsBubble;

--- a/nefac-website/src/pages/nefac-news/index.tsx
+++ b/nefac-website/src/pages/nefac-news/index.tsx
@@ -1,119 +1,31 @@
-import React, { useEffect, useState } from 'react';
+import { useState, useEffect } from 'react';
 import NewsBubble from '@/components/news-page/news-bubble';
 import LeftChevron from '@/components/icons/LeftChevron'
 import RightChevron from '@/components/icons/RightChevron'
 import { WordPressArticle } from "@/components/news-page/article-interface";
 
-export const NewsPage = () => {
-  const [featuredArticle, setFeaturedArticle] = useState<WordPressArticle | null>(null);
-  const [newsArticles, setNewsArticles] = useState<WordPressArticle[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<String>('');
+import { gql } from '@apollo/client';
+import { getNextServerSideProps } from '@faustwp/core';
+
+export const NewsPage = ( props: WordPressArticle ) => {
   const [currentPage, setCurrentPage] = useState(1);
-  const [totalPages, setTotalPages] = useState(1);
-  const [totalPosts, setTotalPosts] = useState(0);
   const articlesPerPage = 8;
+  const posts = props.data?.posts.nodes || [];
+  const featuredArticle = posts[0] || null;
+  const iDsMinusFeatured = posts.slice(1).map((post) => post.id);
 
-  const fetchFeatured = async () => {
-    try {
-      const baseUrl = 'https://nefac.org/wp-json/wp/v2/posts';
-      const url = new URL(baseUrl);
-      url.searchParams.append('per_page', '1');
-      url.searchParams.append('page', '1');
-      url.searchParams.append('_embed', 'true');
+  const calculatedTotalPages = Math.ceil((posts.length - 1) / articlesPerPage);
+  const totalPages = (calculatedTotalPages > 0 ? calculatedTotalPages : 1);
 
-      const response = await fetch(url.toString());
-      if (!response.ok) {
-        throw new Error('Failed to fetch featured article');
-      }
-      const data = await response.json();
-      if (data.length > 0) {
-        setFeaturedArticle(data[0]);
-      }
-    } catch (error) {
-      console.error('Error fetching featured article:', error);
-    }
-  };
-
-  const fetchNews = async (pageNum = 1) => {
-    try {
-      setLoading(true);
-      const baseUrl = 'https://nefac.org/wp-json/wp/v2/posts';
-      const url = new URL(baseUrl);
-      const offset = (pageNum - 1) * articlesPerPage + 1;
-
-      url.searchParams.append('per_page', articlesPerPage.toString());
-      url.searchParams.append('offset', offset.toString());
-      url.searchParams.append('_embed', 'true');
-
-      const response = await fetch(url.toString());
-      if (!response.ok) {
-        throw new Error('Failed to fetch news articles');
-      }
-
-      const data = await response.json();
-
-      const totalPosts = parseInt(response.headers.get('X-WP-TotalPages') || '1');
-      setTotalPosts(totalPosts);
-
-      const calculatedTotalPages = Math.ceil((totalPosts - 1) / articlesPerPage);
-      setTotalPages(calculatedTotalPages > 0 ? calculatedTotalPages : 1);
-
-      setNewsArticles(data);
-    } catch (err) {
-      setError((err as Error).message);
-      console.error('Error fetching news articles:', (err as Error).message);
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  useEffect(() => {
-    const loadInitialData = async () => {
-      await fetchFeatured();
-      await fetchNews(1);
-    };
-
-    loadInitialData();
-  }, []);
-
-  useEffect(() => {
-    if (currentPage > 1 || featuredArticle) {
-      fetchNews(currentPage);
-    }
-  }, [currentPage]);
+  const [currPageIds, setCurrPgaeIds] = useState(iDsMinusFeatured.slice(0, articlesPerPage));
 
   const handlePageChange = (pageNum: number = 1) => {
     if (pageNum >= 1 && pageNum <= totalPages) {
       setCurrentPage(pageNum);
+      setCurrPgaeIds(iDsMinusFeatured.slice(
+        (pageNum - 1) * articlesPerPage,
+        pageNum * articlesPerPage));
     }
-  };
-
-  const formatDate = (dateString: string) => {
-    const options = { year: "numeric" as const, month: "long" as const, day: "numeric" as const};
-    return new Date(dateString).toLocaleDateString('en-US', options);
-  };
-
-  const stripHTML = (html: string) => {
-    const doc = new DOMParser().parseFromString(html, 'text/html');
-    return doc.body.textContent || '';
-  };
-
-  const removeAuthor = (excerpt: string) => {
-    const plainText = stripHTML(excerpt);
-    const authorPattern = /^By\s+(([A-Za-z]+(\s+[A-Za-z]+)?)(,?\s+and\s+|\s*,\s*)?)+?\s+(?=[A-Z])/;
-    const match = plainText.match(authorPattern);
-    if (match && match[0]) {
-      return excerpt.replace(match[0], '').trim();
-    }
-
-    return excerpt;
-  }
-
-  const getImageFromArticle = (article: string) => {
-    const imgRegex = /<img[^>]+src="([^">]+)"/;
-    const match = article.match(imgRegex);
-    return match ? match[1] : null;
   };
 
   const generatePageNumbers = () => {
@@ -135,20 +47,13 @@ export const NewsPage = () => {
     return pages;
   };
 
-  if (loading && currentPage === 1 && !featuredArticle) {
+  if (currentPage === 1 && !featuredArticle) {
+    console.log(posts)
+    console.log('No featured article available');
     return (
       <div className="mx-20 pt-12">
         <h1 className="text-nefacblue font-semibold text-5xl">NEFAC News</h1>
         <div className="mt-8">Loading news articles...</div>
-      </div>
-    );
-  }
-
-  if (error && !featuredArticle) {
-    return (
-      <div className="mx-20 pt-12">
-        <h1 className="text-nefacblue font-semibold text-5xl">NEFAC News</h1>
-        <div className="mt-8 text-red-500">Error: {error}</div>
       </div>
     );
   }
@@ -158,31 +63,16 @@ export const NewsPage = () => {
         <h1 className="text-nefacblue font-semibold text-5xl mb-4">NEFAC News</h1>
         {featuredArticle && (
           <NewsBubble
-          image={
-            featuredArticle.featured_media && featuredArticle._embedded?.['wp:featuredmedia']?.[0]?.source_url
-              ? featuredArticle._embedded?.['wp:featuredmedia']?.[0]?.source_url
-              : getImageFromArticle(featuredArticle.content.rendered) || '/images/computer.png'
-          }
-          title={featuredArticle.title.rendered}
-          date={formatDate(featuredArticle.date)}
-          link={`/news/${featuredArticle.slug}`}
-          header={true}
-          headerPreview={removeAuthor(featuredArticle.excerpt.rendered)}
+            id={featuredArticle.id}
+            header={true}
         />
         )}
         
         <h2 className="text-nefacblue font-semibold text-4xl mb-4">Latest News</h2>
         <div className="grid grid-flow-row grid-cols-4 gap-8 gap-y-4 mb-6">
-          {newsArticles.map((article) => (
+          {currPageIds.map((id) => (
             <NewsBubble
-              key={article.id}
-              image={
-                article.featured_media && article._embedded?.['wp:featuredmedia']?.[0]?.source_url 
-                ? article._embedded?.['wp:featuredmedia']?.[0]?.source_url
-                : getImageFromArticle(article.content.rendered) || '/images/computer.png'}
-              title={article.title.rendered}
-              date={formatDate(article.date)}
-              link={`/news/${article.slug}`}
+              id={id}
               header={false}
             />
           ))}
@@ -193,7 +83,7 @@ export const NewsPage = () => {
             <div className="flex items-center">
               <button
                 onClick={() => handlePageChange(currentPage - 1)}
-                disabled={currentPage === 1 || loading}
+                disabled={currentPage === 1}
                 className="px-3 py-1 mx-1 rounded-md text-gray-600 disabled:text-gray-300 disabled:cursor-not-allowed"
                 aria-label="Previous Page"
               >
@@ -207,14 +97,14 @@ export const NewsPage = () => {
                     ${currentPage === pageNum 
                     ? 'bg-nefacblue text-white font-bold border-b-2 border-blue-800' 
                     : 'text-gray-700 hover:bg-gray-100'}`}
-                  disabled={loading}
+                  disabled={currentPage === pageNum}
                 >
                   {pageNum}
                 </button>
               ))}
               <button
                     onClick={() => handlePageChange(currentPage + 1)}
-                    disabled={currentPage === totalPages || loading}
+                    disabled={currentPage === totalPages}
                     className="px-3 py-1 mx-1 rounded-md text-gray-600 disabled:text-gray-300 disabled:cursor-not-allowed"
                     aria-label="Next Page"
                 >
@@ -225,6 +115,22 @@ export const NewsPage = () => {
         )}
       </div>
     );
+}
+
+NewsPage.query = gql`
+  query GetPostIds {
+		posts {
+      nodes {
+        id
+      }
+    }
+	}
+`;
+
+export async function getServerSideProps(context) {
+  return getNextServerSideProps(context, {
+    Page: NewsPage,
+  });
 }
 
 export default NewsPage;


### PR DESCRIPTION
ℹ️ Issue

Closes #57 

📝 Description
Faustified the News page, adding GraphQL queries to the NewsBubble component and News page to retrieve post IDs and post information. 

Briefly list the changes made to the code:

Replaced client-side fetching with server-side GraphQL fetching in News page.
Added GraphQL query to NewsBubble component to fetch post information

✔️ Verification
<img width="1465" alt="Screenshot 2025-06-06 at 5 39 52 PM" src="https://github.com/user-attachments/assets/33cb57b3-6cce-4015-b220-e9a39ff04aa2" />

🏕️ (Optional) Future Work / Notes
Fetch only has 10 posts, and design needs to be redone.