### PR TITLE
Responsified Header & Footer with Mobile View  

### DIFF
--- a/nefac-website/src/components/footer.tsx
+++ b/nefac-website/src/components/footer.tsx
@@ -11,41 +11,42 @@ import EventbriteIcon from "./icons/EventbriteIcon";
 import SquareXIcon from "./icons/SquareXIcon";
 import SquareBlueskyIcon from "./icons/SquareBlueskyIcon";
 
-import EmailForm from "./footer/email-form"
+import EmailForm from "./footer/email-form";
 
 // Style constants to reduce duplication
 const styles = {
   // Social media icons
   socialIcon: "text-[25px] hover:opacity-75 transition-opacity",
   socialIconContainer: "w-[25px] h-[25px] hover:opacity-75 transition-opacity",
-  
+
   // Section headers
   sectionHeader: "text-white font-bold",
-  
+
   // Navigation links
   navLink: "text-white underline",
-  
+
   // Bottom links
   bottomLink: "text-white pr-8",
   bottomLinkUnderlined: "text-white pr-8 underline",
-  
+
   // Icon containers
-  iconContainer: "bg-gray-100 rounded-md w-[23px] h-[23px] flex items-center justify-center hover:opacity-75 transition-opacity",
+  iconContainer:
+    "bg-gray-100 rounded-md w-[23px] h-[23px] flex items-center justify-center hover:opacity-75 transition-opacity",
   smallIcon: "w-[15px] h-[15px]",
-  
+
   // Layout
   sectionContainer: "flex flex-col",
 } as const;
 
 // Helper component for social media icons
-const SocialIcon = ({ 
-  icon, 
-  href, 
-  className = styles.socialIcon 
-}: { 
-  icon: any; 
-  href: string; 
-  className?: string; 
+const SocialIcon = ({
+  icon,
+  href,
+  className = styles.socialIcon,
+}: {
+  icon: any;
+  href: string;
+  className?: string;
 }) => (
   <a href={href} target="_blank">
     <FontAwesomeIcon icon={icon} className={className} />
@@ -53,32 +54,26 @@ const SocialIcon = ({
 );
 
 // Helper component for icon containers (TikTok, Eventbrite)
-const IconContainer = ({ 
-  children, 
-  href 
-}: { 
-  children: React.ReactNode; 
-  href: string; 
+const IconContainer = ({
+  children,
+  href,
+}: {
+  children: React.ReactNode;
+  href: string;
 }) => (
   <a href={href} target="_blank">
-    <div className={styles.iconContainer}>
-      {children}
-    </div>
+    <div className={styles.iconContainer}>{children}</div>
   </a>
 );
 
 // Helper component for section headers
-const SectionHeader = ({ 
-  children, 
-  className = "" 
-}: { 
-  children: React.ReactNode; 
-  className?: string; 
-}) => (
-  <h1 className={`${styles.sectionHeader} ${className}`}>
-    {children}
-  </h1>
-);
+const SectionHeader = ({
+  children,
+  className = "",
+}: {
+  children: React.ReactNode;
+  className?: string;
+}) => <h1 className={`${styles.sectionHeader} ${className}`}>{children}</h1>;
 
 export interface FooterProps {
   nefacLogo?: string;
@@ -86,90 +81,103 @@ export interface FooterProps {
 
 const Footer = ({ nefacLogo }: FooterProps) => {
   return (
-    <div className="box-border px-16 pt-12 w-full h-[378px] bg-[#1C1E35]">
+    <div className="box-border px-4 sm:px-8 md:px-16 pt-8 md:pt-12 w-full min-h-[378px] bg-[#1C1E35]">
       <div className="flex flex-col">
-        <div className="flex flex-row justify-between">
-          <img
-            src={nefacLogo ?? "/icons/nefac-logo.svg"}
-            alt="NEFAC LOGO"
-            className="w-[113px] h-[113px] flex-shrink-0"
-          />
-          
-          {/* connect section */}
-          <div className={styles.sectionContainer}>
-            <SectionHeader className="mb-4">Connect with NEFAC</SectionHeader>
-            <nav className="grid grid-cols-2 gap-x-6 gap-y-2">
-              <Link href="/contact" className={styles.navLink}>
-                Contact
-              </Link>
-              <Link href="/join" className={styles.navLink}>
-                Join
-              </Link>
-              <Link href="/donate" className={styles.navLink}>
-                Donate
-              </Link>
-              <Link href="/subscribe" className={styles.navLink}>
-                Subscribe
-              </Link>
-            </nav>
+        <div className="flex flex-col lg:flex-row justify-center gap-14">
+          <div className="flex justify-center lg:justify-start">
+            <img
+              src={nefacLogo ?? "/icons/nefac-logo.svg"}
+              alt="NEFAC LOGO"
+              className="w-20 h-20 md:w-[113px] md:h-[113px] flex-shrink-0"
+            />
           </div>
-          
-          {/* email section */}
-          <div className={styles.sectionContainer}>
-            <SectionHeader className="mb-2">Get Email Updates</SectionHeader>
-            <EmailForm />
-          </div>
-          
-          {/* social media section */}
-          <div className={styles.sectionContainer}>
-            <SectionHeader className="pb-4">Follow Us</SectionHeader>
-            <div className="flex flex-wrap gap-4">
-              <div className="flex flex-row gap-3 items-start text-gray-100">
-                <a href="http://www.twitter.com/fivefreedoms" target="_blank">
-                  <SquareXIcon className={styles.socialIconContainer} />
-                </a>
-                
-                <SocialIcon 
-                  icon={faFacebookSquare} 
-                  href="https://www.facebook.com/nefac.org/" 
-                />
-                <SocialIcon 
-                  icon={faLinkedin} 
-                  href="https://www.linkedin.com/company/nefac/" 
-                />
-                <SocialIcon 
-                  icon={faYoutubeSquare} 
-                  href="https://www.youtube.com/c/fivefreedoms" 
-                />
-                <SocialIcon 
-                  icon={faInstagramSquare} 
-                  href="https://www.instagram.com/nefirstamendmentcoalition/" 
-                />
-                
-                <a href="https://bsky.app/profile/nefac.bsky.social" target="_blank">
-                  <SquareBlueskyIcon className={styles.socialIconContainer} />
-                </a>
-                
-                {/* TikTok icon */}
-                <IconContainer href="https://www.tiktok.com/@fivefreedoms?lang=en&is_copy_url=1&is_from_webapp=v2">
-                  <FontAwesomeIcon
-                    icon={faTiktok}
-                    className={`${styles.smallIcon} text-[#1C1E35]`}
+
+          <div className="flex flex-col md:flex-row gap-8 md:gap-12 lg:gap-16">
+            {/* Connect section */}
+            <div className={styles.sectionContainer}>
+              <SectionHeader className="mb-4 text-center">
+                Connect with NEFAC
+              </SectionHeader>
+              <nav className="grid grid-cols-2 gap-x-6 gap-y-2 justify-items-center">
+                <Link href="/contact" className={styles.navLink}>
+                  Contact
+                </Link>
+                <Link href="/join" className={styles.navLink}>
+                  Join
+                </Link>
+                <Link href="/donate" className={styles.navLink}>
+                  Donate
+                </Link>
+                <Link href="/subscribe" className={styles.navLink}>
+                  Subscribe
+                </Link>
+              </nav>
+            </div>
+
+            {/* Email section */}
+            <div className={styles.sectionContainer}>
+              <SectionHeader className="mb-2 text-center md:text-left">
+                Get Email Updates
+              </SectionHeader>
+              <EmailForm />
+            </div>
+
+            {/* Social Media section */}
+            <div className={styles.sectionContainer}>
+              <SectionHeader className="pb-4 text-center md:text-left">
+                Follow Us
+              </SectionHeader>
+              <div className="flex justify-center md:justify-start">
+                <div className="flex flex-row gap-3 items-start text-gray-100 flex-wrap justify-center">
+                  <a href="http://www.twitter.com/fivefreedoms" target="_blank">
+                    <SquareXIcon className={styles.socialIconContainer} />
+                  </a>
+
+                  <SocialIcon
+                    icon={faFacebookSquare}
+                    href="https://www.facebook.com/nefac.org/"
                   />
-                </IconContainer>
-                
-                {/* Eventbrite icon */}
-                <IconContainer href="https://nefac.eventbrite.com/">
-                  <EventbriteIcon className={`${styles.smallIcon} fill-[#1C1E35]`} />
-                </IconContainer>
+                  <SocialIcon
+                    icon={faLinkedin}
+                    href="https://www.linkedin.com/company/nefac/"
+                  />
+                  <SocialIcon
+                    icon={faYoutubeSquare}
+                    href="https://www.youtube.com/c/fivefreedoms"
+                  />
+                  <SocialIcon
+                    icon={faInstagramSquare}
+                    href="https://www.instagram.com/nefirstamendmentcoalition/"
+                  />
+
+                  <a
+                    href="https://bsky.app/profile/nefac.bsky.social"
+                    target="_blank"
+                  >
+                    <SquareBlueskyIcon className={styles.socialIconContainer} />
+                  </a>
+
+                  <IconContainer href="https://www.tiktok.com/@fivefreedoms?lang=en&is_copy_url=1&is_from_webapp=v2">
+                    <FontAwesomeIcon
+                      icon={faTiktok}
+                      className={`${styles.smallIcon} text-[#1C1E35]`}
+                    />
+                  </IconContainer>
+
+                  <IconContainer href="https://nefac.eventbrite.com/">
+                    <EventbriteIcon
+                      className={`${styles.smallIcon} fill-[#1C1E35]`}
+                    />
+                  </IconContainer>
+                </div>
               </div>
             </div>
           </div>
         </div>
       </div>
-      
-      {/* bottom links */}
-      <div className="w-full flex flex-row gap-10 justify-center mt-16">
+
+      {/* Bottom links */}
+      <div className="w-full flex flex-col sm:flex-row gap-4 sm:gap-10 justify-center items-center mt-12 md:mt-16 text-center">
         <Link href="/donate" className={styles.bottomLink}>
           <span className="mr-1">© 2025</span>
           <span className="underline">

--- a/nefac-website/src/components/header.tsx
+++ b/nefac-website/src/components/header.tsx
@@ -2,7 +2,12 @@
 import React, { useState, useRef } from "react";
 import SearchBar from "./header/search-bar";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faChevronDown } from "@fortawesome/free-solid-svg-icons";
+import {
+  faChevronDown,
+  faBars,
+  faTimes,
+  faChevronRight,
+} from "@fortawesome/free-solid-svg-icons";
 
 export interface HeaderProps {
   nefacLogo?: string;
@@ -12,6 +17,11 @@ const Header = ({ nefacLogo }: HeaderProps) => {
   const [isDropdownOpenAbout, setDropdownOpenAbout] = useState(false);
   const [isDropdownOpenJoin, setDropdownOpenJoin] = useState(false);
   const [isDropdownOpenWWD, setDropdownOpenWWD] = useState(false);
+  const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
+
+  const [isMobileAboutOpen, setIsMobileAboutOpen] = useState(false);
+  const [isMobileWWDOpen, setIsMobileWWDOpen] = useState(false);
+  const [isMobileJoinOpen, setIsMobileJoinOpen] = useState(false);
 
   const aboutTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const joinTimeoutRef = useRef<NodeJS.Timeout | null>(null);
@@ -49,23 +59,48 @@ const Header = ({ nefacLogo }: HeaderProps) => {
     }, 200);
   };
 
+  const toggleMobileMenu = () => {
+    setIsMobileMenuOpen(!isMobileMenuOpen);
+  };
+
+  const toggleMobileAbout = () => {
+    setIsMobileAboutOpen(!isMobileAboutOpen);
+    setIsMobileWWDOpen(false);
+    setIsMobileJoinOpen(false);
+  };
+
+  const toggleMobileWWD = () => {
+    setIsMobileWWDOpen(!isMobileWWDOpen);
+    setIsMobileAboutOpen(false);
+    setIsMobileJoinOpen(false);
+  };
+
+  const toggleMobileJoin = () => {
+    setIsMobileJoinOpen(!isMobileJoinOpen);
+    setIsMobileAboutOpen(false);
+    setIsMobileWWDOpen(false);
+  };
+
   return (
-    <header className="relative flex flex-row justify-between 
-    items-center pt-6 pb-4 px-12 z-50 text-nefacblue border-b-4 bg-white">
-      <div className="flex flex-row items-center gap-8">
-        <a href="/#">
-          <img
-            src={nefacLogo ?? "/icons/nefac-logo.svg"}
-            alt="NEFAC LOGO"
-            className="w-16 h-16"
-          />
-        </a>
-        <SearchBar />
-      </div>
-      <div className="flex flex-row items-center gap-6">
-        <div className="text-[16px] ml-36">
-          <nav className="flex justify-start gap-4 items-center relative">
-            {/* About Dropdown */}
+    <header className="relative bg-white border-b-4 border-nefacblue z-50 w-full">
+      <div className="hidden lg:flex flex-row justify-between items-center w-full px-6 lg:px-10 pt-6 pb-4">
+        {/* Left: Logo + Search */}
+        <div className="flex flex-row items-center gap-4 lg:gap-8 min-w-0 flex-shrink">
+          <a href="/#" className="flex-shrink-0">
+            <img
+              src={nefacLogo ?? "/icons/nefac-logo.svg"}
+              alt="NEFAC LOGO"
+              className="w-16 h-16"
+            />
+          </a>
+          <div className="flex-1 min-w-0">
+            <SearchBar />
+          </div>
+        </div>
+
+        {/* Right: Nav + Donate */}
+        <div className="flex flex-row items-center gap-4 lg:gap-8 min-w-0 flex-1 justify-end">
+          <nav className="flex gap-4 lg:gap-8 items-center min-w-0">
             <div
               className="relative"
               onMouseEnter={handleMouseEnterAbout}
@@ -73,23 +108,29 @@ const Header = ({ nefacLogo }: HeaderProps) => {
             >
               <button className="flex items-center gap-1 p-2 rounded-md hover:bg-gray-200">
                 About
-                <FontAwesomeIcon icon={faChevronDown} className="w-3 h-3 text-nefacblue" />
+                <FontAwesomeIcon icon={faChevronDown} className="w-3 h-3" />
               </button>
               {isDropdownOpenAbout && (
                 <div className="absolute left-0 top-full bg-white shadow-lg rounded-lg w-44 z-50">
-                  <ul className="py-2 text-sm text-black">
+                  <ul className="py-2 text-4 text-gray-600">
                     <li>
-                      <a href="/leadership" className="block px-4 py-2 hover:text-black">
+                      <a
+                        href="/leadership"
+                        className="block px-4 py-2 hover:bg-gray-100"
+                      >
                         Leadership
                       </a>
                     </li>
                     <li>
-                      <a href="#" className="block px-4 py-2 hover:text-black">
+                      <a href="#" className="block px-4 py-2 hover:bg-gray-100">
                         Our Supporters
                       </a>
                     </li>
                     <li>
-                      <a href="sustaining-memberships" className="block px-4 py-2 hover:text-black">
+                      <a
+                        href="sustaining-memberships"
+                        className="block px-4 py-2 hover:bg-gray-100"
+                      >
                         How You Can Help
                       </a>
                     </li>
@@ -97,8 +138,6 @@ const Header = ({ nefacLogo }: HeaderProps) => {
                 </div>
               )}
             </div>
-
-            {/* What We Do Dropdown */}
             <div
               className="relative"
               onMouseEnter={handleMouseEnterWWD}
@@ -106,23 +145,26 @@ const Header = ({ nefacLogo }: HeaderProps) => {
             >
               <button className="flex items-center gap-1 p-2 rounded-md hover:bg-gray-200">
                 <a href="/mission">What We Do</a>
-                <FontAwesomeIcon icon={faChevronDown} className="w-3 h-3 text-nefacblue" />
+                <FontAwesomeIcon icon={faChevronDown} className="w-3 h-3" />
               </button>
               {isDropdownOpenWWD && (
                 <div className="absolute left-0 top-full bg-white shadow-lg rounded-lg w-44 z-50">
-                  <ul className="py-2 text-sm text-black">
+                  <ul className="py-2 text-4 text-gray-600">
                     <li>
-                      <a href="/education" className="block px-4 py-2 hover:text-black">
+                      <a
+                        href="/education"
+                        className="block px-4 py-2 hover:bg-gray-100"
+                      >
                         Education
                       </a>
                     </li>
                     <li>
-                      <a href="#" className="block px-4 py-2 hover:text-black">
+                      <a href="#" className="block px-4 py-2 hover:bg-gray-100">
                         Advocacy
                       </a>
                     </li>
                     <li>
-                      <a href="#" className="block px-4 py-2 hover:text-black">
+                      <a href="#" className="block px-4 py-2 hover:bg-gray-100">
                         Defense
                       </a>
                     </li>
@@ -130,64 +172,70 @@ const Header = ({ nefacLogo }: HeaderProps) => {
                 </div>
               )}
             </div>
-            <a href="/nefac-news/">News</a>
-            <a href="/subscribe">Subscribe</a>
 
-            {/* Join Dropdown */}
+            <a href="/nefac-news/" className="p-2 rounded-md hover:bg-gray-200">
+              News
+            </a>
             <div
               className="relative"
               onMouseEnter={handleMouseEnterJoin}
               onMouseLeave={handleMouseLeaveJoin}
             >
               <button className="flex items-center gap-1 p-2 rounded-md hover:bg-gray-200">
-                Join
-                <FontAwesomeIcon icon={faChevronDown} className="w-3 h-3 text-nefacblue" />
+                Get Involved
+                <FontAwesomeIcon icon={faChevronDown} className="w-3 h-3" />
               </button>
               {isDropdownOpenJoin && (
-                <div className="absolute left-0 top-full bg-white shadow-lg rounded-lg w-44 z-50">
-                  <ul className="py-2 text-sm text-black">
+                <div className="absolute left-0 top-full bg-white shadow-lg rounded-lg w-48 z-50 overflow-y-auto">
+                  <ul className="py-2 text-4 text-gray-600">
                     <li>
-                      <a href="#" className="block px-4 py-2 hover:text-black">
+                      <a href="#" className="block px-4 py-2 hover:bg-gray-100">
                         30 Minute Skills
                       </a>
                     </li>
                     <li>
-                      <a href="#" className="block px-4 py-2 hover:text-black">
+                      <a href="#" className="block px-4 py-2 hover:bg-gray-100">
                         Commentary and Coverage
                       </a>
                     </li>
                     <li>
-                      <a href="#" className="block px-4 py-2 hover:text-black">
+                      <a href="#" className="block px-4 py-2 hover:bg-gray-100">
                         First Amendment and the Free Press
                       </a>
                     </li>
                     <li>
-                      <a href="/education/foi-guide" className="block px-4 py-2 hover:text-black">
+                      <a
+                        href="/education/foi-guide"
+                        className="block px-4 py-2 hover:bg-gray-100"
+                      >
                         FOI Guide
                       </a>
                     </li>
                     <li>
-                      <a href="#" className="block px-4 py-2 hover:text-black">
+                      <a href="#" className="block px-4 py-2 hover:bg-gray-100">
                         Legal Briefs, Letters, and Statements
                       </a>
                     </li>
                     <li>
-                      <a href="#" className="block px-4 py-2 hover:text-black">
+                      <a href="#" className="block px-4 py-2 hover:bg-gray-100">
                         NEFAC Mentors
                       </a>
                     </li>
                     <li>
-                      <a href="/education/negri-institute" className="block px-4 py-2 hover:text-black">
+                      <a
+                        href="/education/negri-institute"
+                        className="block px-4 py-2 hover:bg-gray-100"
+                      >
                         Negri Institute
                       </a>
                     </li>
                     <li>
-                      <a href="#" className="block px-4 py-2 hover:text-black">
+                      <a href="#" className="block px-4 py-2 hover:bg-gray-100">
                         New England First Amendment Awards
                       </a>
                     </li>
                     <li>
-                      <a href="#" className="block px-4 py-2 hover:text-black">
+                      <a href="#" className="block px-4 py-2 hover:bg-gray-100">
                         Sunshine Week
                       </a>
                     </li>
@@ -196,20 +244,223 @@ const Header = ({ nefacLogo }: HeaderProps) => {
               )}
             </div>
           </nav>
-        </div>
 
-        <div className="flex flex-row gap-4 w-span">
-          <a href="/sustaining-memberships">
+          {/* Donate Button */}
+          <a href="/sustaining-memberships" className="flex-shrink-0">
             <button
               type="button"
-              className="text-white bg-[#2F5C9F] rounded-xl w-[117px] h-[36px]"
+              className="text-white bg-[#2F5C9F] rounded-xl px-4 md:px-6 lg:px-10 py-2 text-sm lg:text-base hover:bg-[#1e4a8a] transition-colors flex-1 min-w-0"
             >
               Donate
             </button>
           </a>
         </div>
       </div>
-      
+
+      {/* Mobile View */}
+      <div className="lg:hidden flex flex-row items-center w-full px-2 sm:px-4 py-3 gap-x-2">
+        <a href="/#" className="flex-shrink-0">
+          <img
+            src={nefacLogo ?? "/icons/nefac-logo.svg"}
+            alt="NEFAC LOGO"
+            className="w-10 h-10"
+          />
+        </a>
+        {/* Mobile Search */}
+        <div className="flex-1 min-w-0 mx-2">
+          <SearchBar />
+        </div>
+        {/* Mobile Menu Button */}
+        <button
+          onClick={toggleMobileMenu}
+          className="p-2 text-nefacblue hover:bg-gray-200 rounded-md flex-shrink-0 ml-2 flex items-center justify-center"
+        >
+          <FontAwesomeIcon
+            icon={isMobileMenuOpen ? faTimes : faBars}
+            className="w-5 h-5"
+          />
+        </button>
+      </div>
+
+      {isMobileMenuOpen && (
+        <div className="lg:hidden absolute top-full left-0 right-0 bg-white shadow-lg border-t border-gray-200 z-50">
+          <div className="px-4 py-2">
+            <nav className="flex flex-col space-y-1">
+              <div>
+                <button
+                  onClick={toggleMobileAbout}
+                  className="w-full flex items-center justify-between p-3 hover:bg-gray-100 rounded-md font-medium"
+                >
+                  <span>About</span>
+                  <FontAwesomeIcon
+                    icon={faChevronRight}
+                    className={`w-3 h-3 transition-transform ${
+                      isMobileAboutOpen ? "rotate-180" : ""
+                    }`}
+                  />
+                </button>
+                {isMobileAboutOpen && (
+                  <div className="ml-4 mt-1 space-y-1 text-gray-600">
+                    <a
+                      href="/leadership"
+                      className="block p-3 hover:bg-gray-100 rounded-md text-sm"
+                    >
+                      Leadership
+                    </a>
+                    <a
+                      href="#"
+                      className="block p-3 hover:bg-gray-100 rounded-md text-sm"
+                    >
+                      Our Supporters
+                    </a>
+                    <a
+                      href="sustaining-memberships"
+                      className="block p-3 hover:bg-gray-100 rounded-md text-black text-sm"
+                    >
+                      How You Can Help
+                    </a>
+                  </div>
+                )}
+              </div>
+              <div>
+                <button
+                  onClick={toggleMobileWWD}
+                  className="w-full flex items-center justify-between p-3 hover:bg-gray-100 rounded-md font-medium"
+                >
+                  <span>What We Do</span>
+                  <FontAwesomeIcon
+                    icon={faChevronRight}
+                    className={`w-3 h-3 transition-transform ${
+                      isMobileWWDOpen ? "rotate-180" : ""
+                    }`}
+                  />
+                </button>
+                {isMobileWWDOpen && (
+                  <div className="ml-4 mt-1 space-y-1 text-gray-600">
+                    <a
+                      href="/education"
+                      className="block p-3 hover:bg-gray-100 rounded-md text-sm"
+                    >
+                      Education
+                    </a>
+                    <a
+                      href="#"
+                      className="block p-3 hover:bg-gray-100 rounded-md text-sm"
+                    >
+                      Advocacy
+                    </a>
+                    <a
+                      href="#"
+                      className="block p-3 hover:bg-gray-100 rounded-md text-sm"
+                    >
+                      Defense
+                    </a>
+                  </div>
+                )}
+              </div>
+              <div>
+                <a
+                  href="/nefac-news/"
+                  className="w-full flex items-center justify-between p-3 hover:bg-gray-100 rounded-md font-medium"
+                >
+                  <span>News</span>
+                  <FontAwesomeIcon icon={faChevronRight} className="w-3 h-3" />
+                </a>
+              </div>
+              <div>
+                <a
+                  href="/subscribe"
+                  className="w-full flex items-center justify-between p-3 hover:bg-gray-100 rounded-md font-medium"
+                >
+                  <span>Subscribe</span>
+                  <FontAwesomeIcon icon={faChevronRight} className="w-3 h-3" />
+                </a>
+              </div>
+              <div>
+                <button
+                  onClick={toggleMobileJoin}
+                  className="w-full flex items-center justify-between p-3 hover:bg-gray-100 rounded-md font-medium"
+                >
+                  <span>Get Involved</span>
+                  <FontAwesomeIcon
+                    icon={faChevronRight}
+                    className={`w-3 h-3 transition-transform ${
+                      isMobileJoinOpen ? "rotate-180" : ""
+                    }`}
+                  />
+                </button>
+                {isMobileJoinOpen && (
+                  <div className="ml-4 mt-1 space-y-1 text-gray-600">
+                    <a
+                      href="#"
+                      className="block p-3 hover:bg-gray-100 rounded-md text-sm"
+                    >
+                      30 Minute Skills
+                    </a>
+                    <a
+                      href="#"
+                      className="block p-3 hover:bg-gray-100 rounded-md text-sm"
+                    >
+                      Commentary and Coverage
+                    </a>
+                    <a
+                      href="#"
+                      className="block p-3 hover:bg-gray-100 rounded-md text-sm"
+                    >
+                      First Amendment and the Free Press
+                    </a>
+                    <a
+                      href="/education/foi-guide"
+                      className="block p-3 hover:bg-gray-100 rounded-md text-sm"
+                    >
+                      FOI Guide
+                    </a>
+                    <a
+                      href="#"
+                      className="block p-3 hover:bg-gray-100 rounded-md text-sm"
+                    >
+                      Legal Briefs, Letters, and Statements
+                    </a>
+                    <a
+                      href="#"
+                      className="block p-3 hover:bg-gray-100 rounded-md text-sm"
+                    >
+                      NEFAC Mentors
+                    </a>
+                    <a
+                      href="/education/negri-institute"
+                      className="block p-3 hover:bg-gray-100 rounded-md text-sm"
+                    >
+                      Negri Institute
+                    </a>
+                    <a
+                      href="#"
+                      className="block p-3 hover:bg-gray-100 rounded-md text-sm"
+                    >
+                      New England First Amendment Awards
+                    </a>
+                    <a
+                      href="#"
+                      className="block p-3 hover:bg-gray-100 rounded-md text-sm"
+                    >
+                      Sunshine Week
+                    </a>
+                  </div>
+                )}
+              </div>
+              <div>
+                <a
+                  href="/sustaining-memberships"
+                  className="w-full flex items-center justify-between p-3 hover:bg-gray-100 rounded-md font-medium"
+                >
+                  <span>Donate</span>
+                  <FontAwesomeIcon icon={faChevronRight} className="w-3 h-3" />
+                </a>
+              </div>
+            </nav>
+          </div>
+        </div>
+      )}
     </header>
   );
 };

--- a/nefac-website/src/components/header/search-bar.tsx
+++ b/nefac-website/src/components/header/search-bar.tsx
@@ -1,17 +1,17 @@
 import { Input } from "@/components/ui/input";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faEllipsisV, faSearch } from "@fortawesome/free-solid-svg-icons";
+import { faTimes, faSearch } from "@fortawesome/free-solid-svg-icons";
 
 const SearchBar = () => {
   return (
-    <div className="flex items-center w-[399px] h-[36px] space-x-2 rounded-lg px-3.5 py-2 text-gray-800 border border-gray-300">
+    <div className="flex items-center w-full max-w-[399px] h-[36px] space-x-2 rounded-lg px-3.5 py-2 text-gray-600 border border-gray-300">
       <FontAwesomeIcon icon={faSearch} className="h-4 w-4" />
       <Input
         type="search"
         placeholder="Search"
         className="w-full border-0 h-8"
       />
-      <FontAwesomeIcon icon={faEllipsisV} className="h-4 w-4" />
+      <FontAwesomeIcon icon={faTimes} className="h-4 w-4" />
     </div>
   );
 };


### PR DESCRIPTION
This PR makes the header & footer responsive for screen sizes ranging from desktop to mobile. 

**Header View**

Desktop: 
<img width="2878" height="1006" alt="Screenshot 2025-07-31 at 4 03 12 AM" src="https://github.com/user-attachments/assets/4ee34397-a311-4feb-9657-2d98721e456a" />

Mobile:
(Closed menu)
<img width="376" height="381" alt="Screenshot 2025-07-31 at 4 02 22 AM" src="https://github.com/user-attachments/assets/23472581-2934-4dd1-b4a8-48fbac3ab8d8" />

(Opened menu)
<img width="374" height="666" alt="Screenshot 2025-07-31 at 4 02 42 AM" src="https://github.com/user-attachments/assets/63eadc02-aaed-487c-a0b3-c63c87054543" />

------------------------------------------------------------------------------------------------

**Footer View**
Desktop: 
<img width="2880" height="1494" alt="Screenshot 2025-07-31 at 4 03 31 AM" src="https://github.com/user-attachments/assets/40093988-874b-4a96-ac8f-537319e6898c" />

Mobile: 
<img width="486" height="1000" alt="Screenshot 2025-07-31 at 4 03 37 AM" src="https://github.com/user-attachments/assets/8dc836d1-4510-4241-af5d-ca476540f971" />


New: 
- updated styles, colors, gaps, flex views 
- fixed hard coded width value in search bar that was causing bugs with mobile view 

Functionality:
- Everything works the same still!
